### PR TITLE
Fixed typo on landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Base Rails
-hi
+hiii
 ## Standard Workflow
 
  1. Start the web server by running `bin/server`.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Base Rails
-
+hi
 ## Standard Workflow
 
  1. Start the web server by running `bin/server`.


### PR DESCRIPTION
The landing page had a typo on it. Resolves #2.